### PR TITLE
Rename server setting archive/support-wsi to archive/use-iio-registry

### DIFF
--- a/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/Main.java
@@ -176,7 +176,7 @@ public class Main {
         pt.ua.dicoogle.server.ControlServices.getInstance();
 
         // Register Image Reader for DICOM Objects
-        if (settings.getArchiveSettings().isSupportWSI()) {
+        if (settings.getArchiveSettings().isUseIIORegistry()) {
             IIORegistry.getDefaultInstance().registerServiceProvider(new DicomImageReaderSpi());
             ImageIO.setUseCache(false);
             System.setProperty("dcm4che.useImageIOServiceRegistry", "true");

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/LegacyServerSettings.java
@@ -1217,7 +1217,7 @@ public class LegacyServerSettings implements ServerSettings {
         }
 
         @Override
-        public void setSupportWSI(boolean supportWSI) {}
+        public void setUseIIORegistry(boolean useIIORegistry) {}
 
         @Override
         public void setDirectoryWatcherEnabled(boolean watch) {
@@ -1280,9 +1280,9 @@ public class LegacyServerSettings implements ServerSettings {
             return LegacyServerSettings.this.getWatchDirectory();
         }
 
-        @JsonGetter("support-wsi")
+        @JsonGetter("use-iio-registry")
         @Override
-        public boolean isSupportWSI() {
+        public boolean isUseIIORegistry() {
             return false;
         }
 

--- a/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
+++ b/dicoogle/src/main/java/pt/ua/dicoogle/core/settings/part/ArchiveImpl.java
@@ -18,6 +18,7 @@
  */
 package pt.ua.dicoogle.core.settings.part;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -43,7 +44,7 @@ public class ArchiveImpl implements ServerSettings.Archive {
         a.indexerEffort = 100;
         a.dirWatcherEnabled = false;
         a.watchDirectory = "";
-        a.supportWSI = false;
+        a.useIIORegistry = false;
 
         // Note: make it `true` in Dicoogle 4
         a.callShutdown = false;
@@ -77,8 +78,9 @@ public class ArchiveImpl implements ServerSettings.Archive {
     @JsonProperty("watch-directory")
     private String watchDirectory;
 
-    @JsonProperty(value = "support-wsi", defaultValue = "false")
-    private boolean supportWSI;
+    @JsonProperty(value = "use-iio-registry", defaultValue = "false")
+    @JsonAlias({ "support-wsi" })
+    private boolean useIIORegistry;
 
     @JsonProperty(value = "encrypt-users-file", defaultValue = "false")
     private boolean encryptUsersFile;
@@ -158,12 +160,12 @@ public class ArchiveImpl implements ServerSettings.Archive {
         this.watchDirectory = watchDirectory;
     }
 
-    public boolean isSupportWSI() {
-        return supportWSI;
+    public boolean isUseIIORegistry() {
+        return useIIORegistry;
     }
 
-    public void setSupportWSI(boolean supportWSI) {
-        this.supportWSI = supportWSI;
+    public void setUseIIORegistry(boolean useIIORegistry) {
+        this.useIIORegistry = useIIORegistry;
     }
 
     @Override
@@ -201,7 +203,7 @@ public class ArchiveImpl implements ServerSettings.Archive {
         return "ArchiveImpl{" + "saveThumbnails=" + saveThumbnails + ", thumbnailSize=" + thumbnailSize
                 + ", indexerEffort=" + indexerEffort + ", dimProviders=" + dimProviders + ", defaultStorage="
                 + defaultStorage + ", dirWatcherEnabled=" + dirWatcherEnabled + ", watchDirectory='" + watchDirectory
-                + ", supportWSI='" + supportWSI + '\'' + ", mainDirectory='" + mainDirectory + '\'' + ", nodeName='"
+                + ", useIIORegistry='" + useIIORegistry + '\'' + ", mainDirectory='" + mainDirectory + '\'' + ", nodeName='"
                 + nodeName + '\'' + ", callShutdown=" + callShutdown + ", encryptUsersFile=" + encryptUsersFile + '}';
     }
 }

--- a/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
+++ b/dicoogle/src/test/java/pt/ua/dicoogle/core/settings/ServerSettingsTest.java
@@ -72,6 +72,7 @@ public class ServerSettingsTest {
         assertEquals("dicoogle01", ar.getNodeName());
         assertEquals(true, ar.isEncryptUsersFile());
         assertEquals(true, ar.isCallShutdown());
+        assertEquals(true, ar.isUseIIORegistry());
 
         assertSameContent(Collections.singleton("lucene"), ar.getDIMProviders());
         assertSameContent(Collections.singleton("filestorage"), ar.getDefaultStorage());

--- a/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-new.xml
+++ b/dicoogle/src/test/resources/pt/ua/dicoogle/core/settings/test-config-new.xml
@@ -8,6 +8,7 @@
         <thumbnail-size>128</thumbnail-size>
         <main-directory>/opt/my-data</main-directory>
         <indexer-effort>98</indexer-effort>
+        <support-wsi>true</support-wsi>
         <dim-providers>
             <dim-provider>lucene</dim-provider>
         </dim-providers>

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettings.java
@@ -68,7 +68,7 @@ public interface ServerSettings extends ServerSettingsReader {
 
         void setDirectoryWatcherEnabled(boolean watch);
 
-        void setSupportWSI(boolean supportWSI);
+        void setUseIIORegistry(boolean useIIORegistry);
 
         void setEncryptUsersFile(boolean encrypt);
 

--- a/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
+++ b/sdk/src/main/java/pt/ua/dicoogle/sdk/settings/server/ServerSettingsReader.java
@@ -19,6 +19,7 @@
 
 package pt.ua.dicoogle.sdk.settings.server;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -89,8 +90,14 @@ public interface ServerSettingsReader {
         @JsonGetter("watch-directory")
         String getWatchDirectory();
 
-        @JsonGetter("support-wsi")
-        boolean isSupportWSI();
+        /** Whether to use the Image I/O registry
+         * for DICOM image readers and writers.
+         *
+         * This is particularly useful for WSI support.
+         */
+        @JsonGetter("use-iio-registry")
+        @JsonAlias({ "support-wsi"})
+        boolean isUseIIORegistry();
 
         @JsonGetter("dim-provider")
         @JacksonXmlElementWrapper(localName = "dim-providers")


### PR DESCRIPTION
This resolves the concern raised [here](https://github.com/dicoogle/dicoogle/pull/631#discussion_r1987716236) while keeping it compatible with existing instances still using the other name.

- Rename `support-wsi` to `use-iio-registry` and document setting in getter at server settings reader
- keep `support-wsi` as an alias
- add test coverage for setting this property via alias